### PR TITLE
JService Clue Search Pluggin

### DIFF
--- a/wordpress/wp-content/plugins/sp_jservice_clue_search/includes/JServiceClue.php
+++ b/wordpress/wp-content/plugins/sp_jservice_clue_search/includes/JServiceClue.php
@@ -1,0 +1,251 @@
+<?php
+
+class JServiceClue
+{
+    /** @var string jservice api endpoint for clues */
+    const JSERVICE_API_CLUES = 'http://jservice.io/api/clues';
+
+    /** @var string JSON clues we have pulled from the api */
+    private $clues;
+
+    /** @var int value of the clue in dollars, like songs for $200 would be $value = 200 */
+    private $value;
+
+    /** @var int the category to pull clues for, see http://jservice.io/ */
+    private $category;
+
+    /** @var DateTime filter out clues aired earlier than this date */
+    private $minDate;
+
+    /** @var DateTime filter out clues aired more recent than this date */
+    private $maxDate;
+
+    /** @var int make this clue id your first id, then pull as many as you can (for pagination) */
+    private $offset;
+
+    /** @var bool determine if there are any search filters */
+    private $getAllClues = false;
+
+    /** @var array of errors validating options or calling the api */
+    private $errors = [];
+
+    public function __construct(array $args)
+    {
+        $this->setOpts($args);
+        $this->setClues();
+    }
+
+    private function setOpts(array $args)
+    {
+        if (empty($args)) {
+            $this->getAllClues = true;
+        }
+
+        if (!empty($args['value'])) {
+            $this->setValue($args['value']);
+        }
+
+        if (!empty($args['category'])) {
+            $this->setCategory($args['category']);
+        }
+
+        if (!empty($args['minDate'])) {
+            $this->setMinDate($args['minDate']);
+        }
+
+        if (!empty($args['maxDate'])) {
+            $this->setMaxDate($args['maxDate']);
+        }
+
+        if (!empty($args['offset'])) {
+            $this->setOffset($args['offset']);
+        }
+    }
+
+    public function getClues()
+    {
+        return $this->clues;
+    }
+
+    private function setClues()
+    {
+        if ($this->getAllClues) {
+            $clues = $this->pullAllClues();
+        } else {
+            $url = self::JSERVICE_API_CLUES . '?' . http_build_query($this->getArgs());
+            $ch = curl_init($url);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+            $clues = curl_exec($ch);
+        }
+
+        $this->clues = $clues;
+    }
+
+    private function getArgs()
+    {
+        $args = [];
+
+        if (isset($this->value)) {
+            $args['value'] = $this->value;
+        }
+
+        if (isset($this->category)) {
+            $args['category'] = $this->category;
+        }
+
+        if (isset($this->minDate)) {
+            $args['minDate'] = $this->minDate;
+        }
+
+        if (isset($this->maxDate)) {
+            $args['maxDate'] = $this->maxDate;
+        }
+
+        if (isset($this->offset)) {
+            $args['offset'] = $this->offset;
+        }
+
+        return $args;
+    }
+
+    private function pullAllClues()
+    {
+        $continue = false;
+        $resultsTotal = 0;
+
+        do {
+            $multiCurl = [];
+            $clues = [];
+            $mch = curl_multi_init();
+
+            for ($i = 0; $i < 10; $i++) {
+                $url = self::JSERVICE_API_CLUES . '?offset=' . $resultsTotal;
+                $multiCurl[$i] = curl_init();
+                curl_setopt($multiCurl[$i], CURLOPT_URL, $url);
+                curl_setopt($multiCurl[$i], CURLOPT_HEADER, 0);
+                curl_setopt($multiCurl[$i], CURLOPT_RETURNTRANSFER, 1);
+                curl_multi_add_handle($mch, $multiCurl[$i]);
+                $resultsTotal += 100;
+            }
+
+            $running = false;
+
+            do {
+                curl_multi_exec($mch, $running);
+            } while ($running);
+
+            foreach ($multiCurl as $k => $ch) {
+                $curlData = curl_multi_getcontent($ch);
+
+                if (empty($curlData)) {
+                    $continue = false;
+                } else {
+                    $clues[$k] = $curlData;
+                    $continue = true;
+                }
+
+                curl_multi_remove_handle($mch, $ch);
+            }
+
+            curl_multi_close($mch);
+        } while ($continue);
+
+        return $clues;
+    }
+
+    private function setValue($value)
+    {
+        $errorMsg = 'Value was not valid, ';
+        $valid = true;
+
+        if (!is_numeric($value)) {
+            $valid = false;
+            $this->addError($errorMsg . 'because it was not numeric.');
+        }
+
+        //might be able to get all acceptable values, even if it's not enforced by jservice
+        if ($value <= 0) {
+            $valid = false;
+            $this->addError($errorMsg . 'because it was less than or equal to 0.');
+        }
+
+        if (true === $valid) {
+            $this->value = $value;
+        }
+    }
+
+    private function setCategory($category)
+    {
+        $errorMsg = 'Category was not valid, ';
+        $valid = true;
+
+        if (!is_numeric($category)) {
+            $valid = false;
+            $this->addError($errorMsg . 'because it was not numeric.');
+        }
+
+        if (true === $valid) {
+            $this->category = $category;
+        }
+    }
+
+    private function setMinDate($minDate)
+    {
+        $errorMsg = 'minDate was not valid, ';
+        $valid = true;
+
+        if (false === DateTime::createFromFormat('Y-m-d', $minDate)) {
+            $valid = false;
+            $this->addError($errorMsg . 'because it was not a valid date.');
+        }
+
+        if (true === $valid) {
+            $this->minDate = $minDate;
+        }
+    }
+
+    private function setMaxDate($maxDate)
+    {
+        $errorMsg = 'maxDate was not valid, ';
+        $valid = true;
+
+        if (false === DateTime::createFromFormat('Y-m-d', $maxDate)) {
+            $valid = false;
+            $this->addError($errorMsg . 'because it was not a valid date.');
+        }
+
+        if (true === $valid) {
+            $this->maxDate = $maxDate;
+        }
+    }
+
+    private function setOffset($offset)
+    {
+        $errorMsg = 'Offset was not valid, ';
+        $valid = true;
+
+        if (!is_numeric($offset)) {
+            $valid = false;
+            $this->addError($errorMsg . 'because it was not numeric.');
+        }
+
+        if ($offset < 0) {
+            $valid = false;
+            $this->addError($errorMsg . 'because it was negative.');
+        }
+
+        if (true === $valid) {
+            $this->offset = $offset;
+        }
+    }
+
+    private function addError($error)
+    {
+        $this->errors[] = $error;
+    }
+
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+}

--- a/wordpress/wp-content/plugins/sp_jservice_clue_search/js/JServiceClue.js
+++ b/wordpress/wp-content/plugins/sp_jservice_clue_search/js/JServiceClue.js
@@ -1,0 +1,23 @@
+jQuery(document).ready(function ($) {
+    jQuery("#clueSearch").click(function () {
+        var $form = $("form#clueSearchForm");
+        var clueSearchResults = jQuery("#clueSearchResults");
+        var data = {
+            action: 'sp_jservice_clue_search_action',
+            value: $form.find("input[name='value']").val(),
+            category: $form.find("input[name='category']").val(),
+            minDate: $form.find("input[name='minDate']").val(),
+            maxDate: $form.find("input[name='maxDate']").val(),
+            offset: $form.find("input[name='offset']").val()
+        };
+
+        $.post(ajaxurl, data, function (response) {
+            clueSearchResults.empty();
+            clueSearchResults.append(response);
+        });
+
+        return false;
+    });
+
+    return false;
+});

--- a/wordpress/wp-content/plugins/sp_jservice_clue_search/sp_jservice_clue_search.php
+++ b/wordpress/wp-content/plugins/sp_jservice_clue_search/sp_jservice_clue_search.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+Plugin name: JService Clue Searching Tool
+Plugin URI: http://localhost:8000
+Description: Search JService Clues
+Author: Christopher Rogers
+Author URI: http://localhost:8000
+Version: 1.0.0
+*/
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+include(plugin_dir_path(__FILE__) . 'includes/JServiceClue.php');
+
+register_uninstall_hook(__FILE__, 'sp_jservice_clue_search_uninstall');
+add_action('admin_menu', 'sp_jservice_clue_search_menu');
+register_activation_hook(__FILE__, 'sp_jservice_clue_search_activate');
+add_action('admin_post_sp_jservice_clue_create_post', 'sp_jservice_clue_create_post');
+add_action('wp_ajax_sp_jservice_clue_search_action', 'sp_jservice_clue_search_action');
+wp_register_style('pure', 'https://unpkg.com/purecss@1.0.0/build/pure-min.css');
+wp_enqueue_style('pure');
+wp_enqueue_script('JServiceClue', plugin_dir_url(__FILE__) . 'js/JServiceClue.js', array('jquery'));
+
+function sp_jservice_clue_search_activate()
+{
+    //call recursive function that will pull all clues with pagination
+    //and save it to something?
+    //$jServiceClueObj = new JServiceClue([]);
+    //$jServiceClueObj->getClues();
+}
+
+function sp_jservice_clue_search_uninstall()
+{
+    //undo anything permanent done in activate?
+}
+
+function sp_jservice_clue_search_menu()
+{
+    add_menu_page('Clue Search Page', 'Clue Search', 'manage_options', 'sp_jservice_clue_search_menu', 'sp_jservice_clue_search_menu_option');
+}
+
+function sp_jservice_clue_search_menu_option()
+{
+    sp_jservice_clue_search_form();
+}
+
+function sp_jservice_clue_search_form()
+{
+    $html = '
+        <span><p>Use the form below to search jservice.io for clues</p></span>';
+
+    $html .= '
+        <form class="pure-form pure-form-aligned" id="clueSearchForm" action="">
+            <fieldset>
+                <div class="pure-control-group">
+                    <label for="value">Value</label>
+                    <input id="value" type="text" name="value" placeholder="0">
+                </div>
+                
+                <div class="pure-control-group">
+                    <label for="category">Category</label>
+                    <input id="category" type="text" name="category" placeholder="100">
+                </div>
+                
+                <div class="pure-control-group">
+                    <label for="minDate">Min Date</label>
+                    <input id="minDate" type="text" name="minDate" placeholder="YYYY-MM-DD">
+                </div>
+                
+                <div class="pure-control-group">
+                    <label for="maxDate">Max Date</label>
+                    <input id="maxDate" type="text" name="maxDate" placeholder="YYYY-MM-DD">
+                </div>
+                
+                <div class="pure-control-group">
+                    <label for="offset">Offset</label>
+                    <input id="offset" type="text" name="offset" placeholder="0">
+                </div>
+        
+                <div class="pure-controls">
+                    <button type="submit" id="clueSearch" class="pure-button pure-button-primary">Submit</button>
+                </div>
+            </fieldset>
+        </form>
+        <div id="clueSearchResults"></div>
+        ';
+
+    echo $html;
+}
+
+function sp_jservice_clue_create_post()
+{
+    $postCreationSummary = 'There was an error, and your post was not saved';
+
+    if (!empty($_POST)) {
+        $post = array(
+            'post_title' => $_POST['question'],
+            'post_content' => $_POST['answer'],
+            'post_type' => 'jeopardy',
+        );
+
+        if (wp_insert_post($post)) {
+            $postCreationSummary = 'Post created!';
+        }
+    }
+
+    echo $postCreationSummary;
+    header("refresh:1;url=/wp-admin/admin.php?page=sp_jservice_clue_search_menu");
+    wp_die();
+}
+
+function sp_jservice_clue_search_action()
+{
+    $jServiceClueObj = new JServiceClue($_POST);
+    $errors = $jServiceClueObj->getErrors();
+
+    if (empty($errors)) {
+        $question = $answer = '';
+        $html = '<table class="pure-table">';
+        $cluesArray = json_decode($jServiceClueObj->getClues(), true);
+        $html .= '<thead><tr>';
+        $html .= '<th>Question</th>';
+        $html .= '<th>Answer</th>';
+        $html .= '<th>Value</th>';
+        $html .= '<th>Save</th>';
+        $html .= '</tr></thead><tbody>';
+
+        foreach ($cluesArray as $clues) {
+            $html .= '<tr>';
+
+            foreach ($clues as $key => $value) {
+                if ('question' === $key) {
+                    $question = htmlspecialchars($value);
+                    $html .= '<td>' . $question . '</td>';
+                } else if ('answer' === $key) {
+                    $answer = htmlspecialchars($value);
+                    $html .= '<td>' . $answer . '</td>';
+                } else if ('value' === $key) {
+                    $html .= '<td>' . htmlspecialchars($value) . '</td>';
+                }
+            }
+
+            $html .= '<td>' .
+                '<form action="' . esc_url(admin_url('admin-post.php')) . '" method="post">' .
+                '<input type="hidden" id="question" name="question" value="' . $question . '">' .
+                '<input type="hidden" id="answer" name="answer" value="' . $answer . '">' .
+                '<input type="hidden" name="action" value="sp_jservice_clue_create_post">' .
+                '<input type="submit" value="Save">' .
+                '</form></td></tr>';
+        }
+
+        $html .= '</tbody></table>';
+    } else {
+        $html = 'something broke.. maybe a clue will follow' . PHP_EOL;
+
+        foreach ($errors as $error) {
+            $html .= $error . PHP_EOL;
+        }
+    }
+
+    echo $html;
+    wp_die();
+}

--- a/wordpress/wp-content/plugins/sp_jservice_clue_search/sp_jservice_clue_search.php
+++ b/wordpress/wp-content/plugins/sp_jservice_clue_search/sp_jservice_clue_search.php
@@ -24,6 +24,57 @@ wp_register_style('pure', 'https://unpkg.com/purecss@1.0.0/build/pure-min.css');
 wp_enqueue_style('pure');
 wp_enqueue_script('JServiceClue', plugin_dir_url(__FILE__) . 'js/JServiceClue.js', array('jquery'));
 
+function create_jeopardy_posttype() {
+    register_post_type( 'jeopardy',
+        array(
+            'labels' => array(
+                'name' => __( 'Clues' ),
+                'singular_name' => __( 'Clues' ),
+                'add_new' => __( 'Add Custom Clue'),
+                'edit_item' => __( 'Edit Clue' ),
+                'view_item' => __( 'View Clue' ),
+                'search_items' => __( 'Search Clues' ),
+                'not_found' => __( 'No Clue found' ),
+                'not_found_in_trash' => __( 'No Clue found in trash' ),
+                'parent_item_colon' => __( '' ),
+                'menu_name' => __( 'Clues' )
+            ),
+            'public' => true,
+            'has_archive' => true,
+            'rewrite' => array('slug' => 'clues'),
+            'show_in_menu' => true,
+            'hierarchical' => true,
+            'menu_position' => 21,
+            'capabilities' => array(
+                            'edit_post' => 'edit_clue',
+                            'edit_posts' => 'edit_clues',
+                            'edit_others_posts' => 'edit_other_clues',
+                            'publish_posts' => 'publish_clues',
+                            'read_post' => 'read_clue',
+                            'read_private_posts' => 'read_private_clues',
+                            'delete_post' => 'delete_clue'
+                        ),
+            'map_meta_cap' => true,
+            'supports' => array('title', 'editor', 'author', 'revision')
+        )
+    );
+}
+add_action( 'init', 'create_jeopardy_posttype' );
+
+function add_clue_caps() {
+    $role = get_role( 'administrator' );
+    $role->add_cap( 'edit_clue' ); 
+    $role->add_cap( 'edit_clues' ); 
+    $role->add_cap( 'edit_others_clues' ); 
+    $role->add_cap( 'publish_clues' ); 
+    $role->add_cap( 'read_clue' ); 
+    $role->add_cap( 'read_private_clues' ); 
+    $role->add_cap( 'delete_clue' ); 
+    $role->add_cap( 'edit_published_clues' );   //added
+    $role->add_cap( 'delete_published_clues' ); //added
+  }
+add_action( 'admin_init', 'add_clue_caps');
+
 function sp_jservice_clue_search_activate()
 {
     //call recursive function that will pull all clues with pagination
@@ -39,7 +90,7 @@ function sp_jservice_clue_search_uninstall()
 
 function sp_jservice_clue_search_menu()
 {
-    add_menu_page('Clue Search Page', 'Clue Search', 'manage_options', 'sp_jservice_clue_search_menu', 'sp_jservice_clue_search_menu_option');
+    add_submenu_page('edit.php?post_type=jeopardy', 'Clue API Search', 'Clue API Search', "manage_options", 'sp_jservice_clue_search_menu', 'sp_jservice_clue_search_menu_option', '');
 }
 
 function sp_jservice_clue_search_menu_option()
@@ -100,6 +151,7 @@ function sp_jservice_clue_create_post()
             'post_title' => $_POST['question'],
             'post_content' => $_POST['answer'],
             'post_type' => 'jeopardy',
+            'post_status' => 'publish'
         );
 
         if (wp_insert_post($post)) {


### PR DESCRIPTION
creating a wordpress pluggin that allows an admin to use the JService Clue API endpoint to search clues, displays the results with a "Save" button per clues that creates a new "jeopardy" entry in wp_posts with the clues question and answer.